### PR TITLE
support concurrent fabric8 releases and automate docs + website version change

### DIFF
--- a/maven/Fabric8DevOpsRelease.groovy
+++ b/maven/Fabric8DevOpsRelease.groovy
@@ -29,9 +29,19 @@ def getReleaseVersion(String project) {
   return version
 }
 
-stage 'canary release fabric8-devop'
+def getRepoId() {
+  new File("/var/jenkins_home/fabric8-devops/target/nexus-staging/staging").eachFileMatch(~/.*\.properties/) { filter ->
+    def props = new java.util.Properties()
+    props.load(new FileInputStream(filter))
+    def config = new ConfigSlurper().parse(props)
+    // return after matching the first file
+    return config.stagingRepository.id
+  }
+}
+
+stage 'canary release fabric8-devops'
 node {
-  ws ('fabric8-devop'){
+  ws ('fabric8-devops'){
     withEnv(["PATH+MAVEN=${tool 'maven-3.3.1'}/bin"]) {
       def project = "fabric8io/fabric8-devops"
 
@@ -61,11 +71,9 @@ node {
 
       // lets avoid using the maven release plugin so we have more control over the release
       sh "mvn org.codehaus.mojo:versions-maven-plugin:2.2:set -DnewVersion=${releaseVersion}"
-      sh "mvn -V -B -U clean install org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy -P release -DaltReleaseDeploymentRepository=oss-sonatype-staging::default::https://oss.sonatype.org/service/local/staging/deploy/maven2"
+      sh "mvn -V -B -U clean install org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy -P release -DnexusUrl=https://oss.sonatype.org -DserverId=oss-sonatype-staging"
 
-      // get the repo id and store it in a file see https://issues.jenkins-ci.org/browse/JENKINS-26133
-      sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-list -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org | grep OPEN | grep -Eo 'iofabric8-[[:digit:]]+' > repoId.txt"
-      def repoId = readFile('repoId.txt').trim()
+      def repoId = getRepoId()
 
       if(isRelease == 'true'){
         try {
@@ -75,8 +83,7 @@ node {
             sh "mvn docker:push -P release"
           }
 
-          // close and release the sonartype staging repo
-          sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-close -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org -DstagingRepositoryId=${repoId} -Ddescription=\"Next release is ready\" -DstagingProgressTimeoutMinutes=60"
+          // release the sonartype staging repo
           sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-release -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org -DstagingRepositoryId=${repoId} -Ddescription=\"Next release is ready\" -DstagingProgressTimeoutMinutes=60"
 
         } catch (err) {

--- a/maven/Fabric8DocsUpdate.groovy
+++ b/maven/Fabric8DocsUpdate.groovy
@@ -1,0 +1,44 @@
+
+def getReleaseVersion(String project) {
+  def modelMetaData = new XmlSlurper().parse("https://oss.sonatype.org/content/repositories/releases/io/fabric8/"+project+"/maven-metadata.xml")
+  def version = modelMetaData.versioning.release.text()
+  return version
+}
+def oldVersion() {
+  def matcher = readFile('website/src/docs/index.page') =~ '<h1>Documentation for version (.+)</h1>'
+  matcher ? matcher[0][1] : null
+}
+
+// this flow works out the old version from the website then replaces all occurrences with the new version that has been released
+stage 'update fabric8 docs'
+node {
+  ws ('fabric8'){
+    withEnv(["PATH+MAVEN=${tool 'maven-3.3.1'}/bin"]) {
+      def project = "fabric8io/fabric8"
+
+      sh "rm -rf *.*"
+      git "https://github.com/${project}"
+      sh "git remote set-url origin git@github.com:${project}.git"
+
+      sh "git config user.email fabric8-admin@googlegroups.com"
+      sh "git config user.name fusesource-ci"
+
+      sh "git checkout master"
+
+      def oldVersion = oldVersion()
+      if (oldVersion == null){
+        echo "No previous version found"
+        return
+      }
+      echo oldVersion
+      def newVersion = getReleaseVersion("fabric8-maven-plugin")
+
+      // use perl so that we we can easily turn off regex in the SED query
+      sh "find . -name '*.md' ! -name Changes.md ! -path '*/docs/jube/**.*' | xargs perl -p -i -e 's/\\Q${oldVersion}/${newVersion}/g'"
+      sh "find . -path '*/website/src/**.*' | xargs perl -p -i -e 's/\\Q${oldVersion}/${newVersion}/g'"
+
+      sh "git commit -a -m '[CD] Update docs following ${newVersion} release'"
+      sh "git push origin master"
+    }
+  }
+}

--- a/maven/Fabric8Release.groovy
+++ b/maven/Fabric8Release.groovy
@@ -66,7 +66,7 @@ node {
           def kubernetesModelVersion = getReleaseVersion("kubernetes-model")
           sh "sed -i -r 's/<kubernetes-model.version>[0-9][0-9]{0,2}.[0-9][0-9]{0,2}.[0-9][0-9]{0,2}/<kubernetes-model.version>${kubernetesModelVersion}/g' pom.xml"
           sh "sed -i -r 's/<kubernetes-client.version>[0-9][0-9]{0,2}.[0-9][0-9]{0,2}.[0-9][0-9]{0,2}/<kubernetes-client.version>${kubernetesClientVersion}/g' pom.xml"
-          sh "git commit -a -m 'Bump fabric8 version'"
+          sh "git commit -a -m 'Bump kubernetes-client and kubernetes-model versions'"
         } catch (err) {
           echo "Already on the latest versions of fabric8 dependencies"
         }

--- a/maven/Fabric8Release.groovy
+++ b/maven/Fabric8Release.groovy
@@ -29,6 +29,16 @@ def getReleaseVersion(String project) {
   return version
 }
 
+def getRepoId() {
+  new File("/var/jenkins_home/fabric8/target/nexus-staging/staging").eachFileMatch(~/.*\.properties/) { filter ->
+    def props = new java.util.Properties()
+    props.load(new FileInputStream(filter))
+    def config = new ConfigSlurper().parse(props)
+    // return after matching the first file
+    return config.stagingRepository.id
+  }
+}
+
 stage 'canary release fabric8-devop'
 node {
   ws ('fabric8'){
@@ -64,16 +74,13 @@ node {
 
       // lets avoid using the maven release plugin so we have more control over the release
       sh "mvn org.codehaus.mojo:versions-maven-plugin:2.2:set -DnewVersion=${releaseVersion}"
-      sh "mvn -V -B -U clean install org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy -P release -DaltReleaseDeploymentRepository=oss-sonatype-staging::default::https://oss.sonatype.org/service/local/staging/deploy/maven2"
+      sh "mvn -V -B -U clean install org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy -P release -DnexusUrl=https://oss.sonatype.org -DserverId=oss-sonatype-staging"
 
-      // get the repo id and store it in a file see https://issues.jenkins-ci.org/browse/JENKINS-26133
-      sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-list -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org | grep OPEN | grep -Eo 'iofabric8-[[:digit:]]+' > repoId.txt"
-      def repoId = readFile('repoId.txt').trim()
+      def repoId = getRepoId()
 
       if(isRelease == 'true'){
         try {
-          // close and release the sonartype staging repo
-          sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-close -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org -DstagingRepositoryId=${repoId} -Ddescription=\"Next release is ready\" -DstagingProgressTimeoutMinutes=60"
+          // release the sonartype staging repo
           sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-release -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org -DstagingRepositoryId=${repoId} -Ddescription=\"Next release is ready\" -DstagingProgressTimeoutMinutes=60"
 
         } catch (err) {

--- a/maven/Fabric8iPaaSRelease.groovy
+++ b/maven/Fabric8iPaaSRelease.groovy
@@ -29,6 +29,16 @@ def getReleaseVersion(String project) {
   return version
 }
 
+def getRepoId() {
+  new File("/var/jenkins_home/fabric8-ipaas/target/nexus-staging/staging").eachFileMatch(~/.*\.properties/) { filter ->
+    def props = new java.util.Properties()
+    props.load(new FileInputStream(filter))
+    def config = new ConfigSlurper().parse(props)
+    // return after matching the first file
+    return config.stagingRepository.id
+  }
+}
+
 stage 'canary release fabric8-ipaas'
 node {
   ws ('fabric8-ipaas'){
@@ -63,9 +73,7 @@ node {
       sh "mvn org.codehaus.mojo:versions-maven-plugin:2.2:set -DnewVersion=${releaseVersion}"
       sh "mvn -V -B -U clean install org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy -P release -DnexusUrl=https://oss.sonatype.org -DserverId=oss-sonatype-staging"
 
-      // get the repo id and store it in a file see https://issues.jenkins-ci.org/browse/JENKINS-26133
-      sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-list -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org | grep OPEN | grep -Eo 'iofabric8-[[:digit:]]+' > repoId.txt"
-      def repoId = readFile('repoId.txt').trim()
+      def repoId = getRepoId()
 
       if(isRelease == 'true'){
         try {
@@ -75,8 +83,7 @@ node {
             sh "mvn docker:push -P release -Ddocker.username=${env.DOCKER_REGISTRY_USERNAME} -Ddocker.password=${env.DOCKER_REGISTRY_PASSWORD}"
           }
 
-          // close and release the sonartype staging repo
-          sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-close -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org -DstagingRepositoryId=${repoId} -Ddescription=\"Next release is ready\" -DstagingProgressTimeoutMinutes=60"
+          // release the sonartype staging repo
           sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-release -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org -DstagingRepositoryId=${repoId} -Ddescription=\"Next release is ready\" -DstagingProgressTimeoutMinutes=60"
 
         } catch (err) {

--- a/maven/Fabric8iPaaSRelease.groovy
+++ b/maven/Fabric8iPaaSRelease.groovy
@@ -61,7 +61,7 @@ node {
 
       // lets avoid using the maven release plugin so we have more control over the release
       sh "mvn org.codehaus.mojo:versions-maven-plugin:2.2:set -DnewVersion=${releaseVersion}"
-      sh "mvn -V -B -U clean install org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy -P release -DaltReleaseDeploymentRepository=oss-sonatype-staging::default::https://oss.sonatype.org/service/local/staging/deploy/maven2"
+      sh "mvn -V -B -U clean install org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy -P release -DnexusUrl=https://oss.sonatype.org -DserverId=oss-sonatype-staging"
 
       // get the repo id and store it in a file see https://issues.jenkins-ci.org/browse/JENKINS-26133
       sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-list -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org | grep OPEN | grep -Eo 'iofabric8-[[:digit:]]+' > repoId.txt"

--- a/maven/KubernetesClientRelease.groovy
+++ b/maven/KubernetesClientRelease.groovy
@@ -29,6 +29,16 @@ def getReleaseVersion(String project) {
   return version
 }
 
+def getRepoId() {
+  new File("/var/jenkins_home/kubernetes-client/target/nexus-staging/staging").eachFileMatch(~/.*\.properties/) { filter ->
+    def props = new java.util.Properties()
+    props.load(new FileInputStream(filter))
+    def config = new ConfigSlurper().parse(props)
+    // return after matching the first file
+    return config.stagingRepository.id
+  }
+}
+
 stage 'canary release kubernetes client'
 node {
   ws ('kubernetes-client'){
@@ -62,16 +72,13 @@ node {
 
       // lets avoid using the maven release plugin so we have more control over the release
       sh "mvn org.codehaus.mojo:versions-maven-plugin:2.2:set -DnewVersion=${releaseVersion}"
-      sh "mvn -V -B -U clean install org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy -P release -DaltReleaseDeploymentRepository=oss-sonatype-staging::default::https://oss.sonatype.org/service/local/staging/deploy/maven2"
+      sh "mvn -V -B -U clean install org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy -P release -DnexusUrl=https://oss.sonatype.org -DserverId=oss-sonatype-staging"
 
-      // get the repo id and store it in a file see https://issues.jenkins-ci.org/browse/JENKINS-26133
-      sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-list -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org | grep OPEN | grep -Eo 'iofabric8-[[:digit:]]+' > repoId.txt"
-      def repoId = readFile('repoId.txt').trim()
+      def repoId = getRepoId()
 
       if(isRelease == 'true'){
         try {
-          // close and release the sonartype staging repo
-          sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-close -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org -DstagingRepositoryId=${repoId} -Ddescription=\"Next release is ready\" -DstagingProgressTimeoutMinutes=60"
+          // release the sonartype staging repo
           sh "mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:rc-release -DserverId=oss-sonatype-staging -DnexusUrl=https://oss.sonatype.org -DstagingRepositoryId=${repoId} -Ddescription=\"Next release is ready\" -DstagingProgressTimeoutMinutes=60"
 
         } catch (err) {

--- a/maven/Test.groovy
+++ b/maven/Test.groovy
@@ -1,36 +1,61 @@
-def valid = 'true'
+def getRepoId() {
+  new File("/var/jenkins_home/fabric8-ipaas/target/nexus-staging/staging").eachFileMatch(~/.*\.properties/) { filter ->
+    def props = new java.util.Properties()
+    props.load(new FileInputStream(filter))
+    def config = new ConfigSlurper().parse(props)
+    //def repoId = config.stagingRepository.id
+    return config.stagingRepository.id
 
-stage 'test-fabric8-devops'
+  }
+}
+
+stage 'test'
 node {
-   ws ('fabric8-devops') {
+   ws ('fabric8-ipaas-2') {
     // lets install maven onto the path
     withEnv(["PATH+MAVEN=${tool 'maven-3.3.1'}/bin"]) {
-      sh "rm -rf *.*"
-      git 'https://github.com/fabric8io/fabric8-devops'
 
-      sh "git remote set-url origin git@github.com:fabric8io/fabric8-devops.git"
-      sh "git config user.email fabric8-admin@googlegroups.com"
-      sh "git config user.name fusesource-ci"
+      def repoId = getRepoId()
 
-      
-      sh "git tag -d \$(git tag)"
-      sh "git fetch --tags"
-      sh "git reset --hard origin/master"
-
-      def test = "test-tag4"
-      sh "git tag -a ${test} -m 'Release version ${test}'"
-      sh "git push origin ${test}"
-
-      sh "echo 'Test for CD release'>> README.md"
-      sh "git commit -a -m 'Dummy commit to test auth from CD infra'"
-      sh "git push origin master"
-
-      sh "git tag -d ${test}"
-      sh "git push origin :refs/tags/${test}"
+      sh "echo ${repoId}"
     }
   }
 }
 
+
+// def valid = 'true'
+//
+// stage 'test-fabric8-devops'
+// node {
+//    ws ('fabric8-devops') {
+//     // lets install maven onto the path
+//     withEnv(["PATH+MAVEN=${tool 'maven-3.3.1'}/bin"]) {
+//       sh "rm -rf *.*"
+//       git 'https://github.com/fabric8io/fabric8-devops'
+//
+//       sh "git remote set-url origin git@github.com:fabric8io/fabric8-devops.git"
+//       sh "git config user.email fabric8-admin@googlegroups.com"
+//       sh "git config user.name fusesource-ci"
+//
+//
+//       sh "git tag -d \$(git tag)"
+//       sh "git fetch --tags"
+//       sh "git reset --hard origin/master"
+//
+//       def test = "test-tag4"
+//       sh "git tag -a ${test} -m 'Release version ${test}'"
+//       sh "git push origin ${test}"
+//
+//       sh "echo 'Test for CD release'>> README.md"
+//       sh "git commit -a -m 'Dummy commit to test auth from CD infra'"
+//       sh "git push origin master"
+//
+//       sh "git tag -d ${test}"
+//       sh "git push origin :refs/tags/${test}"
+//     }
+//   }
+// }
+//
 
 
 // stage 'test'

--- a/maven/Test.groovy
+++ b/maven/Test.groovy
@@ -4,14 +4,9 @@ node {
     // lets install maven onto the path
     withEnv(["PATH+MAVEN=${tool 'maven-3.3.1'}/bin"]) {
 
-      def matcher = readFile('target/nexus-staging/staging/\*.properties')
+      def matcher = readFile('target/nexus-staging/staging/*.properties')
 
       echo matcher
-      //def repoId readFile
-      //def repoId = getRepoId()
-      //def repoId = getRepoId()
-
-      //sh "echo ${repoId}"
     }
   }
 }

--- a/maven/Test.groovy
+++ b/maven/Test.groovy
@@ -1,23 +1,17 @@
-def getRepoId() {
-  new File("/var/jenkins_home/fabric8-ipaas/target/nexus-staging/staging").eachFileMatch(~/.*\.properties/) { filter ->
-    def props = new java.util.Properties()
-    props.load(new FileInputStream(filter))
-    def config = new ConfigSlurper().parse(props)
-    //def repoId = config.stagingRepository.id
-    return config.stagingRepository.id
-
-  }
-}
-
 stage 'test'
 node {
-   ws ('fabric8-ipaas-2') {
+   ws ('kubernetes-model') {
     // lets install maven onto the path
     withEnv(["PATH+MAVEN=${tool 'maven-3.3.1'}/bin"]) {
 
-      def repoId = getRepoId()
+      def matcher = readFile('target/nexus-staging/staging/\*.properties')
 
-      sh "echo ${repoId}"
+      echo matcher
+      //def repoId readFile
+      //def repoId = getRepoId()
+      //def repoId = getRepoId()
+
+      //sh "echo ${repoId}"
     }
   }
 }


### PR DESCRIPTION
This change switches from using the maven deploy plugin to the nexus plugin.  This allows us to obtain the stagingRepoID when performing a deploy so that we can subsequently release that repo and still deploy other fabric8 projects at the same time.
