### PR TITLE
stash artifacts after staging so they can be used during release stag…

### DIFF
--- a/src/io/fabric8/Fabric8Commands.groovy
+++ b/src/io/fabric8/Fabric8Commands.groovy
@@ -6,10 +6,6 @@ def getGitRepo(){
   'fabric8io'
 }
 
-def getLatestFabric8MavenPluginVersion(){
-  '2.2.65'
-}
-
 def getProjectVersion(){
   def file = readFile('pom.xml')
   def project = new XmlSlurper().parseText(file)
@@ -141,8 +137,6 @@ def dropStagingRepo(String repoId){
 def helm(){
   def pluginVersion = getReleaseVersion("io/fabric8/fabric8-maven-plugin")
   try {
-    sh "mvn clean compile"
-    sh "mvn io.fabric8:fabric8-maven-plugin:${pluginVersion}:attach"
     sh "mvn io.fabric8:fabric8-maven-plugin:${pluginVersion}:helm"
     sh "mvn io.fabric8:fabric8-maven-plugin:${pluginVersion}:helm-push"
   } catch (err) {
@@ -155,10 +149,10 @@ def updateGithub(){
   // push release versions and tag it
   def releaseVersion = getProjectVersion()
 
-  sh "git tag -a v${releaseVersion} -m 'Release version ${releaseVersion}'"
+  sh "git tag -fa v${releaseVersion} -m 'Release version ${releaseVersion}'"
   sh "git push origin release-v${releaseVersion}"
-  // also push the tag
-  sh "git push origin v${releaseVersion}"
+  // also force push the tag incase release fails further along the pipeline
+  sh "git push --force origin v${releaseVersion}"
 }
 
 def updateNextDevelopmentVersion(String releaseVersion){

--- a/vars/release.groovy
+++ b/vars/release.groovy
@@ -14,9 +14,7 @@ def call(body) {
           def repoIds = config.projectStagingDetails[2]
 
           def flow = new io.fabric8.Fabric8Commands()
-          flow.setupWorkspace(name)
-          sh "git fetch"
-          sh "git checkout release-v${version}"
+          unstash name:'staged'
 
           echo "About to release ${name} repo ids ${repoIds}"
           for(int j = 0; j < repoIds.size(); j++){

--- a/vars/stageProject.groovy
+++ b/vars/stageProject.groovy
@@ -38,6 +38,9 @@ def call(body) {
 
         def repoId = flow.stageSonartypeRepo()
         releaseVersion = flow.getProjectVersion()
+
+        stash excludes: '*/src/', includes: '**', name: 'staged'
+
         flow.updateGithub ()
 
         return [config.project, releaseVersion, repoId]

--- a/vars/tagImages.groovy
+++ b/vars/tagImages.groovy
@@ -16,7 +16,12 @@ def call(body) {
               sh "docker pull docker.io/fabric8/${image}:staged"
               sh "docker tag -f docker.io/fabric8/${image}:staged docker.io/fabric8/${image}:${config.tag}"
             } catch (err) {
-              hubot room: 'release', message: "WARNING No staged tag found for image ${image} so will apply release tag to :latest"
+              try {
+                //hubot room: 'release', message: "WARNING No staged tag found for image ${image} so will apply release tag to :latest"
+                echo "WARNING No staged tag found for image ${image} so will apply release tag to :latest"
+              } catch (err1) {
+                echo 'unable to send hubot message'
+              }
               sh "docker pull docker.io/fabric8/${image}:latest"
               sh "docker tag -f docker.io/fabric8/${image}:latest docker.io/fabric8/${image}:${config.tag}"
             }


### PR DESCRIPTION
…e fixes fabric8io/fabric8#5349
- also force push the tag incase there's a failure in a later stage which means we trigger again.  We dont want to use a new version as the previous attempt was never released.
