### PR TITLE
if jenkinsfile is not copied to workspace during project create wizar…

### DIFF
--- a/workflows/django/CanaryReleaseStage/Jenkinsfile
+++ b/workflows/django/CanaryReleaseStage/Jenkinsfile
@@ -3,7 +3,7 @@ def utils = new io.fabric8.Utils()
 
 node {
   def envStage = utils.environmentNamespace('staging')
-  checkout scm
+  git GIT_URL
 
   stage 'Canary release'
   if (!fileExists ('Dockerfile')) {

--- a/workflows/django/CanaryReleaseStageAndApprovePromote/Jenkinsfile
+++ b/workflows/django/CanaryReleaseStageAndApprovePromote/Jenkinsfile
@@ -5,7 +5,7 @@ node {
   def envStage = utils.environmentNamespace('staging')
   def envProd = utils.environmentNamespace('production')
 
-  checkout scm
+  git GIT_URL
 
   stage 'Canary release'
   if (!fileExists ('Dockerfile')) {

--- a/workflows/golang/CanaryReleaseStage/Jenkinsfile
+++ b/workflows/golang/CanaryReleaseStage/Jenkinsfile
@@ -4,7 +4,7 @@ def utils = new io.fabric8.Utils()
 node {
   def envStage = utils.environmentNamespace('staging')
 
-  checkout scm
+  git GIT_URL
 
   stage 'Canary release'
   if (!fileExists ('Dockerfile')) {

--- a/workflows/golang/CanaryReleaseStageAndApprovePromote/Jenkinsfile
+++ b/workflows/golang/CanaryReleaseStageAndApprovePromote/Jenkinsfile
@@ -5,7 +5,7 @@ node {
   def envStage = utils.environmentNamespace('staging')
   def envProd = utils.environmentNamespace('production')
 
-  checkout scm
+  git GIT_URL
 
   stage 'Canary release'
   if (!fileExists ('Dockerfile')) {

--- a/workflows/maven/CanaryReleaseAndStage/Jenkinsfile
+++ b/workflows/maven/CanaryReleaseAndStage/Jenkinsfile
@@ -26,7 +26,7 @@ def utils = new io.fabric8.Utils()
 node {
   def envStage = utils.environmentNamespace('staging')
 
-  checkout scm
+  git GIT_URL
 
   kubernetes.pod('buildpod').withImage('fabric8/maven-builder')
       .withPrivileged(true)

--- a/workflows/maven/CanaryReleaseStageAndApprovePromote/Jenkinsfile
+++ b/workflows/maven/CanaryReleaseStageAndApprovePromote/Jenkinsfile
@@ -29,7 +29,7 @@ node {
   def envStage = utils.environmentNamespace('staging')
   def envProd = utils.environmentNamespace('production')
 
-  checkout scm
+  git GIT_URL
 
   kubernetes.pod('buildpod').withImage('fabric8/maven-builder')
       .withPrivileged(true)

--- a/workflows/node/CanaryReleaseStage/Jenkinsfile
+++ b/workflows/node/CanaryReleaseStage/Jenkinsfile
@@ -4,7 +4,7 @@ def utils = new io.fabric8.Utils()
 node {
   def envStage = utils.environmentNamespace('staging')
 
-  checkout scm
+  git GIT_URL
 
   stage 'Canary release'
   if (!fileExists ('Dockerfile')) {

--- a/workflows/node/CanaryReleaseStageAndApprovePromote/Jenkinsfile
+++ b/workflows/node/CanaryReleaseStageAndApprovePromote/Jenkinsfile
@@ -5,7 +5,7 @@ node {
   def envStage = utils.environmentNamespace('staging')
   def envProd = utils.environmentNamespace('production')
 
-  checkout scm
+  git GIT_URL
 
   stage 'Canary release'
   if (!fileExists ('Dockerfile')) {

--- a/workflows/rails/CanaryReleaseStage/Jenkinsfile
+++ b/workflows/rails/CanaryReleaseStage/Jenkinsfile
@@ -4,7 +4,7 @@ def utils = new io.fabric8.Utils()
 node {
   def envStage = utils.environmentNamespace('staging')
 
-  checkout scm
+  git GIT_URL
 
   stage 'Canary release'
   if (!fileExists ('Dockerfile')) {

--- a/workflows/rails/CanaryReleaseStageAndApprovePromote/Jenkinsfile
+++ b/workflows/rails/CanaryReleaseStageAndApprovePromote/Jenkinsfile
@@ -5,7 +5,7 @@ node {
   def envStage = utils.environmentNamespace('staging')
   def envProd = utils.environmentNamespace('production')
 
-  checkout scm
+  git GIT_URL
 
   stage 'Canary release'
   if (!fileExists ('Dockerfile')) {

--- a/workflows/swift/CanaryReleaseStage/Jenkinsfile
+++ b/workflows/swift/CanaryReleaseStage/Jenkinsfile
@@ -4,7 +4,7 @@ def utils = new io.fabric8.Utils()
 node {
   def envStage = utils.environmentNamespace('staging')
 
-  checkout scm
+  git GIT_URL
 
   stage 'Canary release'
   if (!fileExists ('Dockerfile')) {

--- a/workflows/swift/CanaryReleaseStageAndApprovePromote/Jenkinsfile
+++ b/workflows/swift/CanaryReleaseStageAndApprovePromote/Jenkinsfile
@@ -5,7 +5,7 @@ node {
   def envStage = utils.environmentNamespace('staging')
   def envProd = utils.environmentNamespace('production')
 
-  checkout scm
+  git GIT_URL
 
   stage 'Canary release'
   if (!fileExists ('Dockerfile')) {


### PR DESCRIPTION
…d then workflow libs URL is used to clone project, switch back to using parameterised value fixes fabric8io/fabric8#5916
