### PR TITLE
Use semver to do version updates if possible

### DIFF
--- a/vars/stageProject.groovy
+++ b/vars/stageProject.groovy
@@ -33,7 +33,9 @@ def call(body) {
 
     sh "git remote set-url origin git@github.com:${config.project}.git"
 
-    flow.setupWorkspaceForRelease(config.project, config.useGitTagForNextVersion, extraSetVersionArgs)
+    def currentVersion = flow.getProjectVersion()
+
+    flow.setupWorkspaceForRelease(config.project, config.useGitTagForNextVersion, extraSetVersionArgs, currentVersion)
 
     repoId = flow.stageSonartypeRepo()
     releaseVersion = flow.getProjectVersion()


### PR DESCRIPTION
@rhuss @rawlingsj What do you think of this? This should mean you can e.g. bump the minor version in your SNAPSHOT version & next tag will use that minor version. For example, say you're using 1.3-SNAPSHOT & tags are being released 1.3.1, 1.3.2, 1.3.3, etc. You want to bump minor version, you should be able to just bump pom version to 1.4-SNAPSHOT & next release will be 1.4.0, then 1.4.1, etc. Same for major version.

Hard to test, but if you're happy with it I'd like to try it for kubernetes-client release (which was the actual use case for this).
